### PR TITLE
remove null values from values and deduplicate timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This module requires the frontend module:
 ## Installation Requirements
 
 * PHP version ≥ 8.0
-* Icinga2 ElasticsearchWriter or ElasticsearchDatastreamWriter
+* Icinga2 ElasticsearchWriter or OTLPMetricsWriter
 * IcingaDB or IDO Database
 * Elasticsearch

--- a/application/forms/PerfdataGraphsElasticsearchConfigForm.php
+++ b/application/forms/PerfdataGraphsElasticsearchConfigForm.php
@@ -3,7 +3,7 @@
 namespace Icinga\Module\Perfdatagraphselasticsearch\Forms;
 
 use Icinga\Module\Perfdatagraphselasticsearch\Client\ElasticsearchClient;
-use Icinga\Module\Perfdatagraphselasticsearch\Client\ElasticsearchDatastreamClient;
+use Icinga\Module\Perfdatagraphselasticsearch\Client\OTLPMetricsClient;
 
 use Icinga\Forms\ConfigForm;
 
@@ -28,7 +28,7 @@ class PerfdataGraphsElasticsearchConfigForm extends ConfigForm
                 ['' => sprintf(' - %s - ', t('Please choose'))],
                 [
                     'ElasticsearchWriter' => 'ElasticsearchWriter',
-                    'ElasticsearchDatastreamWriter' => 'ElasticsearchDatastreamWriter',
+                    'OTLPMetricsWriter' => 'OTLPMetricsWriter',
                 ]
             ),
             'disable' => [''],
@@ -37,14 +37,12 @@ class PerfdataGraphsElasticsearchConfigForm extends ConfigForm
             'value' => ''
         ]);
 
-        if (isset($formData['elasticsearch_icinga_writer']) && $formData['elasticsearch_icinga_writer'] === 'ElasticsearchWriter') {
-            $this->addElement('text', 'elasticsearch_api_index', [
-                'label' => t('Icinga2 Index'),
-                'description' => t('Name of the index that is configured in Icinga2'),
-                'required' => true,
-                'placeholder' => 'icinga2',
-            ]);
-        }
+        $this->addElement('text', 'elasticsearch_api_index', [
+            'label' => t('Icinga2 Index'),
+            'description' => t('Name of the index that is configured in Icinga2'),
+            'required' => true,
+            'placeholder' => 'icinga2',
+        ]);
 
         $this->addElement('text', 'elasticsearch_api_url', [
             'label' => t('API URLs'),
@@ -172,7 +170,7 @@ class PerfdataGraphsElasticsearchConfigForm extends ConfigForm
         if ($writer === 'ElasticsearchWriter') {
             $c = new ElasticsearchClient($baseURI, $username, $password, $maxDataPoints, $timeout, $tlsVerify, $index);
         } else {
-            $c = new ElasticsearchDatastreamClient($baseURI, $username, $password, $maxDataPoints, $timeout, $tlsVerify);
+            $c = new OTLPMetricsClient($baseURI, $username, $password, $maxDataPoints, $timeout, $tlsVerify);
         }
 
         $status = $c->status();

--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -2,4 +2,4 @@
 
 An Elasticsearch backend for the Icinga Web Performance Data Graphs Module.
 
-It is meant to be used with the Icinga2 ElasticsearchWriter or ElasticsearchDatastreamWriter.
+It is meant to be used with the Icinga2 ElasticsearchWriter or OTLPMetricsWriter.

--- a/library/Perfdatagraphselasticsearch/Client/ElasticsearchClient.php
+++ b/library/Perfdatagraphselasticsearch/Client/ElasticsearchClient.php
@@ -106,7 +106,6 @@ class ElasticsearchClient extends BaseClient implements ESInterface
         return $keys;
     }
 
-
     /**
      * request calls the Opensearch HTTP API, decodes and returns the data.
      *

--- a/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
+++ b/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
@@ -44,7 +44,7 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
         $transport = new Transport($HTTPClient, $pool);
 
         if (isset($username)) {
-            $transport->setBasicAuth($username, $password = '');
+            $transport->setBasicAuth($username, $password);
         }
 
         $this->transport = $transport;
@@ -195,10 +195,8 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
                 if (!isset($criticals[$label])) {
                     $criticals[$label] = [];
                 }
-
                 $timestamps[$label][] = (int) end($d['fields']['@timestamp']);
 
-                // TODO this wont work cause we get a doc for each warn/crit
                 if (array_key_exists('threshold_type', $doc['attributes'])) {
                     if ($doc['attributes']['threshold_type'] === 'warning') {
                         $warnings[$label][] = $doc['metrics']['state_check.threshold'];
@@ -232,23 +230,32 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
             //     $u = end($units[$metric]);
             // }
 
+            $uniqueTimestamps[$metric] = array_unique($timestamps[$metric]);
             $s = new PerfdataSet($metric, $u);
-
-            $s->setTimestamps($timestamps[$metric]);
+            $s->setTimestamps($uniqueTimestamps[$metric]);
 
             if (array_key_exists($metric, $values)) {
-                $v = new PerfdataSeries('value', $values[$metric]);
-                $s->addSeries($v);
+                $values[$metric] = array_filter($values[$metric], fn($v) => $v !== null);
+                if (!empty($values[$metric])) {
+                    $v = new PerfdataSeries('value', $values[$metric]);
+                    $s->addSeries($v);
+                }
             }
 
             if (array_key_exists($metric, $warnings) && !empty($warnings[$metric])) {
-                $w = new PerfdataSeries('warning', $warnings[$metric]);
-                $s->addSeries($w);
+                $warnings[$metric] = array_filter($warnings[$metric], fn($v) => $v !== null);
+                if (!empty($warnings[$metric])) {
+                    $w = new PerfdataSeries('warning', $warnings[$metric]);
+                    $s->addSeries($w);
+                }
             }
 
             if (array_key_exists($metric, $criticals) && !empty($criticals[$metric])) {
-                $c = new PerfdataSeries('critical', $criticals[$metric]);
-                $s->addSeries($c);
+                $criticals[$metric] = array_filter($criticals[$metric], fn($v) => $v !== null);
+                if (!empty($criticals[$metric])) {
+                    $c = new PerfdataSeries('critical', $criticals[$metric]);
+                    $s->addSeries($c);
+                }
             }
 
             $pfr->addDataset($s);

--- a/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
+++ b/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
@@ -230,11 +230,14 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
             //     $u = end($units[$metric]);
             // }
 
+            // We do this because warning and critical thresholds are delivered by a seperate doc element.
+            // Otherwise the same timestamp occurs multiple times which affects the graph rendering
             $uniqueTimestamps[$metric] = array_unique($timestamps[$metric]);
             $s = new PerfdataSet($metric, $u);
             $s->setTimestamps($uniqueTimestamps[$metric]);
 
             if (array_key_exists($metric, $values)) {
+                // This filters out all null values of the array to make sure the graphs are displayed correctly
                 $values[$metric] = array_filter($values[$metric], fn($v) => $v !== null);
                 if (!empty($values[$metric])) {
                     $v = new PerfdataSeries('value', $values[$metric]);
@@ -243,6 +246,7 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
             }
 
             if (array_key_exists($metric, $warnings) && !empty($warnings[$metric])) {
+                // This filters out all null values of the array to make sure the graphs are displayed correctly
                 $warnings[$metric] = array_filter($warnings[$metric], fn($v) => $v !== null);
                 if (!empty($warnings[$metric])) {
                     $w = new PerfdataSeries('warning', $warnings[$metric]);
@@ -251,6 +255,7 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
             }
 
             if (array_key_exists($metric, $criticals) && !empty($criticals[$metric])) {
+                // This filters out all null values of the array to make sure the graphs are displayed correctly
                 $criticals[$metric] = array_filter($criticals[$metric], fn($v) => $v !== null);
                 if (!empty($criticals[$metric])) {
                     $c = new PerfdataSeries('critical', $criticals[$metric]);

--- a/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
+++ b/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
@@ -117,6 +117,9 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
             'size' => 2000,
             'sort' => '@timestamp:asc',
             'body' => [
+                'fields' => [
+                    ['field' => '@timestamp', 'format' => 'epoch_second' ]
+                ],
                 'query' => [
                     'bool' => [
                         'must' => [
@@ -193,19 +196,25 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
                     $criticals[$label] = [];
                 }
 
-                $timestamps[$label][] = (int) $doc['@timestamp'] / 1000;
+                $timestamps[$label][] = (int) end($d['fields']['@timestamp']);
 
+                // TODO this wont work cause we get a doc for each warn/crit
                 if (array_key_exists('threshold_type', $doc['attributes'])) {
-                    if ($doc['attributes']['threshold_type'] == 'warning') {
+                    if ($doc['attributes']['threshold_type'] === 'warning') {
                         $warnings[$label][] = $doc['metrics']['state_check.threshold'];
                     }
-                    if ($doc['attributes']['threshold_type'] == 'critical') {
+                    if ($doc['attributes']['threshold_type'] === 'critical') {
                         $criticals[$label][] = $doc['metrics']['state_check.threshold'];
                     }
+                } else {
+                    $warnings[$label][] = null;
+                    $criticals[$label][] = null;
                 }
 
                 if (array_key_exists('state_check.perfdata', $doc['metrics'])) {
                     $values[$label][] = $doc['metrics']['state_check.perfdata'];
+                } else {
+                    $values[$label][] = null;
                 }
             }
 
@@ -232,12 +241,12 @@ class OTLPMetricsClient extends BaseClient implements ESInterface
                 $s->addSeries($v);
             }
 
-            if (array_key_exists($metric, $warnings) && !empty($warnings)) {
+            if (array_key_exists($metric, $warnings) && !empty($warnings[$metric])) {
                 $w = new PerfdataSeries('warning', $warnings[$metric]);
                 $s->addSeries($w);
             }
 
-            if (array_key_exists($metric, $criticals) && !empty($criticals)) {
+            if (array_key_exists($metric, $criticals) && !empty($criticals[$metric])) {
                 $c = new PerfdataSeries('critical', $criticals[$metric]);
                 $s->addSeries($c);
             }

--- a/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
+++ b/library/Perfdatagraphselasticsearch/Client/OTLPMetricsClient.php
@@ -15,13 +15,14 @@ use Icinga\Util\Json;
 
 use GuzzleHttp\Client;
 use Exception;
-use DateTime;
 
 /**
- * ElasticsearchDatastreamClient is used with with Icinga2 ElasticsearchDatastreamWriter
+ * OTLPMetricsClient is used with with Icinga2 ElasticsearchWriter
  */
-class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
+class OTLPMetricsClient extends BaseClient implements ESInterface
 {
+    protected string $index;
+
     public function __construct(
         string $urls,
         string $username,
@@ -29,6 +30,7 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         int $maxDataPoints,
         int $timeout,
         bool $tlsVerify,
+        string $index = 'icinga2'
     ) {
         $u = explode(',', $urls);
 
@@ -50,7 +52,7 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
     }
 
     /**
-     * fromConfig returns a new Client from this module's configuration
+     * fromConfig returns a new Elasticsearch Client from this module's configuration
      *
      * @param Config $moduleConfig configuration to load (used for testing)
      * @return $this
@@ -59,6 +61,7 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
     {
         $default = [
             'api_url' => 'http://localhost:9200',
+            'api_index' => 'icinga2',
             'api_timeout' => 10,
             'api_max_data_points' => 10000,
             'api_username' => '',
@@ -78,6 +81,7 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         }
 
         $baseURI = rtrim($moduleConfig->get('elasticsearch', 'api_url', $default['api_url']), '/');
+        $index = rtrim($moduleConfig->get('elasticsearch', 'api_index', $default['api_index']), 'icinga2');
         $timeout = (int) $moduleConfig->get('elasticsearch', 'api_timeout', $default['api_timeout']);
         $maxDataPoints = (int) $moduleConfig->get('elasticsearch', 'api_max_data_points', $default['api_max_data_points']);
         $username = $moduleConfig->get('elasticsearch', 'api_username', $default['api_username']);
@@ -85,25 +89,7 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         // Hint: We use a "skip TLS" logic in the UI, but Guzzle uses "verify TLS"
         $tlsVerify = !(bool) $moduleConfig->get('elasticsearch', 'api_tls_insecure', $default['api_tls_insecure']);
 
-        return new static($baseURI, $username, $password, $maxDataPoints, $timeout, $tlsVerify);
-    }
-
-    /**
-     * normalizeCheckcommand mimic the ElasticsearchDatastreamWriter's normalization.
-     * Any leading whitespace and leading special characters are trimmed;
-     * All remaining special (non-alphanumeric) characters are replaced with an underscore;
-     * Consecutive underscores are collapsed;
-     * Leading/trailing underscores are removed;
-     */
-    protected function normalizeCheckcommand(string $n)
-    {
-        $n = preg_replace('/^[\s\W_]+/u', '', $n);
-        $n = preg_replace('/[^A-Za-z0-9]+/u', '_', $n);
-        $n = preg_replace('/_+/', '_', $n);
-        $n = trim($n, '_');
-        $n = mb_strtolower($n, 'UTF-8');
-
-        return $n;
+        return new static($baseURI, $username, $password, $maxDataPoints, $timeout, $tlsVerify, $index);
     }
 
     /**
@@ -131,11 +117,12 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
             'size' => 2000,
             'sort' => '@timestamp:asc',
             'body' => [
-                // Still might cause an out-out-memory, but a lower value means more HTTP requests to the API
                 'query' => [
                     'bool' => [
                         'must' => [
-                            [ 'match' => [ 'service.name' => $hostName .'!'. $serviceName ] ],
+                            [ 'match' => [ 'resource.attributes.icinga2.host.name' => $hostName ] ],
+                            [ 'match' => [ 'resource.attributes.icinga2.service.name' => $serviceName ] ],
+                            [ 'match' => [ 'resource.attributes.icinga2.command.name' => $checkCommand ] ]
                         ],
                         'filter' => [
                             'range' => [ '@timestamp' => [ 'gte' => $from, 'lte' => 'now', ] ]
@@ -148,13 +135,14 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         // If it's a hostalive check we dont need the service term
         if ($isHostCheck) {
             $params['body']['query']['bool']['must'] = [
-                [ 'term' => [ 'host.name' => $hostName ] ],
+                [ 'term' => [ 'resource.attributes.icinga2.host.name' => $hostName ] ],
+                [ 'term' => [ 'resource.attributes.icinga2.command.name' => $checkCommand ] ]
             ];
         }
 
-        $pfr = new PerfdataResponse();
-
         $searchAfter = null;
+
+        $pfr = new PerfdataResponse();
 
         // Where we store the data for each page of hits.
         $timestamps = [];
@@ -163,11 +151,8 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         $criticals = [];
         $units = [];
 
-        $params['index'] = 'metrics-icinga2.' . $this->normalizeCheckcommand($checkCommand) . '-default';
-
         do {
             if ($searchAfter !== null) {
-                // Set the search_after to get the next page of docs
                 $params['body']['search_after'] = [$searchAfter];
             }
 
@@ -184,28 +169,43 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
                 $hits = $response['hits']['hits'] ?? [];
             }
 
-            foreach ($hits as $doc) {
-                $perfdata = $doc['_source']['perfdata'] ?? [];
+            foreach ($hits as $d) {
+                $doc = $d['_source'];
+                $label = $doc['attributes']['perfdata_label'];
 
-                foreach ($perfdata as $label => $metric) {
-                    if (!$this->isIncluded($label, $includeMetrics)) {
-                        continue;
+                if (!$this->isIncluded($label, $includeMetrics)) {
+                    continue;
+                }
+
+                if ($this->isExcluded($label, $excludeMetrics)) {
+                    continue;
+                }
+
+                if (!isset($values[$label])) {
+                    $values[$label] = [];
+                }
+
+                if (!isset($warnings[$label])) {
+                    $warnings[$label] = [];
+                }
+
+                if (!isset($criticals[$label])) {
+                    $criticals[$label] = [];
+                }
+
+                $timestamps[$label][] = (int) $doc['@timestamp'] / 1000;
+
+                if (array_key_exists('threshold_type', $doc['attributes'])) {
+                    if ($doc['attributes']['threshold_type'] == 'warning') {
+                        $warnings[$label][] = $doc['metrics']['state_check.threshold'];
                     }
-
-                    if ($this->isExcluded($label, $excludeMetrics)) {
-                        continue;
+                    if ($doc['attributes']['threshold_type'] == 'critical') {
+                        $criticals[$label][] = $doc['metrics']['state_check.threshold'];
                     }
+                }
 
-                    if (!isset($values[$label])) {
-                        $values[$label] = [];
-                    }
-
-                    $values[$label][] = $metric['value'] ?? null;
-                    $date = new DateTime($doc['_source']['@timestamp']);
-                    $timestamps[$label][] = $date->getTimestamp();
-                    $warnings[$label][] = $metric['warn'] ?? null;
-                    $criticals[$label][] = $metric['crit'] ?? null;
-                    $units[$label][] = $metric['unit'] ?? '';
+                if (array_key_exists('state_check.perfdata', $doc['metrics'])) {
+                    $values[$label][] = $doc['metrics']['state_check.perfdata'];
                 }
             }
 
@@ -217,29 +217,29 @@ class ElasticsearchDatastreamClient extends BaseClient implements ESInterface
         } while ($hitCount > 0);
 
         // Add it to the PerfdataResponse
-        // TODO: we can optize that by doing it in the while loop
-        foreach (array_keys($values) as $label) {
+        foreach (array_keys($values) as $metric) {
             $u = '';
-            if (array_key_exists($label, $units)) {
-                $u = end($units[$label]);
+            // if (array_key_exists($metric, $units)) {
+            //     $u = end($units[$metric]);
+            // }
+
+            $s = new PerfdataSet($metric, $u);
+
+            $s->setTimestamps($timestamps[$metric]);
+
+            if (array_key_exists($metric, $values)) {
+                $v = new PerfdataSeries('value', $values[$metric]);
+                $s->addSeries($v);
             }
 
-            $s = new PerfdataSet($label, $u);
-            $s->setTimestamps($timestamps[$label]);
-
-            if (array_key_exists($label, $values)) {
-                $vSeries = new PerfdataSeries('value', $values[$label]);
-                $s->addSeries($vSeries);
+            if (array_key_exists($metric, $warnings) && !empty($warnings)) {
+                $w = new PerfdataSeries('warning', $warnings[$metric]);
+                $s->addSeries($w);
             }
 
-            if (array_key_exists($label, $warnings) && !empty($warnings)) {
-                $wSeries = new PerfdataSeries('warning', $warnings[$label]);
-                $s->addSeries($wSeries);
-            }
-
-            if (array_key_exists($label, $criticals) && !empty($criticals)) {
-                $cSeries = new PerfdataSeries('critical', $criticals[$label]);
-                $s->addSeries($cSeries);
+            if (array_key_exists($metric, $criticals) && !empty($criticals)) {
+                $c = new PerfdataSeries('critical', $criticals[$metric]);
+                $s->addSeries($c);
             }
 
             $pfr->addDataset($s);

--- a/library/Perfdatagraphselasticsearch/ProvidedHook/Perfdatagraphs/PerfdataSource.php
+++ b/library/Perfdatagraphselasticsearch/ProvidedHook/Perfdatagraphs/PerfdataSource.php
@@ -10,6 +10,7 @@ use Icinga\Module\Perfdatagraphs\Hook\PerfdataSourceHook;
 use Icinga\Module\Perfdatagraphs\Model\PerfdataRequest;
 use Icinga\Module\Perfdatagraphs\Model\PerfdataResponse;
 
+use Icinga\Application\Benchmark;
 use Icinga\Application\Config;
 
 use GuzzleHttp\Exception\RequestException;
@@ -60,6 +61,8 @@ class PerfdataSource extends PerfdataSourceHook
         $now = new DateTime();
         $from = $client->parseDuration($now, $req->getDuration());
 
+        Benchmark::measure('Fetching performance data from Elasticsearch');
+
         // Let's fetch the data from the Elasticsearch API
         try {
             $perfdataresponse = $client->fetchMetrics(
@@ -78,6 +81,8 @@ class PerfdataSource extends PerfdataSourceHook
         } catch (Exception $e) {
             $perfdataresponse->addError($e->getMessage());
         }
+
+        Benchmark::measure('Fetched performance data from Elasticsearch');
 
         return $perfdataresponse;
     }

--- a/library/Perfdatagraphselasticsearch/ProvidedHook/Perfdatagraphs/PerfdataSource.php
+++ b/library/Perfdatagraphselasticsearch/ProvidedHook/Perfdatagraphs/PerfdataSource.php
@@ -4,7 +4,7 @@ namespace Icinga\Module\Perfdatagraphselasticsearch\ProvidedHook\PerfdataGraphs;
 
 use Icinga\Module\Perfdatagraphselasticsearch\Client\ESInterface;
 use Icinga\Module\Perfdatagraphselasticsearch\Client\ElasticsearchClient;
-use Icinga\Module\Perfdatagraphselasticsearch\Client\ElasticsearchDatastreamClient;
+use Icinga\Module\Perfdatagraphselasticsearch\Client\OTLPMetricsClient;
 
 use Icinga\Module\Perfdatagraphs\Hook\PerfdataSourceHook;
 use Icinga\Module\Perfdatagraphs\Model\PerfdataRequest;
@@ -32,8 +32,8 @@ class PerfdataSource extends PerfdataSourceHook
             return $client;
         }
 
-        if ($writer === 'ElasticsearchDatastreamWriter') {
-            $client = ElasticsearchDatastreamClient::fromConfig();
+        if ($writer === 'OTLPMetricsWriter') {
+            $client = OTLPMetricsClient::fromConfig();
             return $client;
         }
 


### PR DESCRIPTION
I removed duplicated Timestamps which affected the view of critical and warning thresholds. Also I filter out all null values of the array which makes the display of the graphs work correctly